### PR TITLE
Cluster A.2: honest fixes from the remaining-items audit

### DIFF
--- a/.agents/skills/lfe-archivist/SKILL.md
+++ b/.agents/skills/lfe-archivist/SKILL.md
@@ -54,8 +54,12 @@ Keep the project's documentation and history perfectly in sync with the codebase
    - `hygiene_report.md` is owned by the Hygiene sub-pipeline — do NOT delete it from a per-mission Archivist run; leave it for `/lfe-improve-architecture` to consume and clear.
    - Update `pipeline_status.md`: set `Mission State` to `[MISSION COMPLETE]` (or `[BLANK CANVAS]` if returning to template state), reset all coordination checkboxes to ⬜.
 6. **Update Pipeline Status (cross-cutting fields)**: Beyond the checkbox/persona resets handled by Step 5a/5b, set the cross-cutting entrance-card fields for the next session — Mission, Session Count, Last ADR, and `Mission State`. The legal `Mission State` values are `[BLANK CANVAS]`, `[DOMAIN LOADED]`, `[IN-FLIGHT: <phase>]`, `[MISSION COMPLETE]`.
-7. **Hygiene Check**: Read `Last Architecture Sweep` from `pipeline_status.md`. If 5+ sessions since last sweep, flag it:
-   > *"Architecture sweep is due (5+ sessions). Run `/lfe-improve-architecture`?"*
+7. **Hygiene Check**: Read `Last Architecture Sweep` from `pipeline_status.md`. If 5+ sessions since last sweep, flag it. Surface the trade-off so the human can decide with context:
+   - **If `03_slices.md` exists with unfinished slices** (multi-slice mission in progress):
+     > *"Architecture sweep is due (5+ sessions). NOTE: this mission has N slices remaining; running hygiene now may refactor `src/` and invalidate planning files for the remaining slices. Run / defer to mission end / skip this cycle?"*
+   - **Otherwise** (mission complete or single-slice):
+     > *"Architecture sweep is due (5+ sessions). Run `/lfe-improve-architecture`?"*
+   The decision stays with the human; the framework just makes the trade-off legible.
 
 ## Checklist
 - [ ] CHANGELOG has exactly 7 or fewer milestones?

--- a/.agents/skills/lfe-builder/SKILL.md
+++ b/.agents/skills/lfe-builder/SKILL.md
@@ -43,7 +43,7 @@ phase: builder
 step: builder
 status: complete
 timestamp: <ISO-8601>
-source: active_plan.md
+source: .plans/active_plan.md
 slice: <copied from active_plan.md>
 ---
 ```

--- a/.agents/skills/lfe-diagnose/SKILL.md
+++ b/.agents/skills/lfe-diagnose/SKILL.md
@@ -31,7 +31,7 @@ phase: inspector
 step: diagnose
 status: complete
 timestamp: <ISO-8601>
-source: tdd_report.md
+source: .plans/tdd_report.md
 slice: <copied from active_plan.md — used by /lfe-builder to detect a stale report>
 ---
 ```

--- a/.agents/skills/lfe-hygiene/SKILL.md
+++ b/.agents/skills/lfe-hygiene/SKILL.md
@@ -94,4 +94,4 @@ source: n/a
 - Proceed to `/lfe-improve-architecture` for architecture sweep? (Yes/No)
 ```
 
-If fully clean, the report still gets written — body reads `Repo is LFE-Compliant. Zero Drift Detected.` Critical findings MUST be resolved by the Architect before any further refactoring.
+If fully clean, the report still gets written — body reads `Repo is LFE-Compliant. Zero Drift Detected.` Critical findings should be reviewed and triaged by the human before further refactoring; the framework surfaces the findings but does not block work — when to act on them is a human judgment call (typical defer reason: mid-mission, hold until completion).

--- a/.agents/skills/lfe-improve-architecture/SKILL.md
+++ b/.agents/skills/lfe-improve-architecture/SKILL.md
@@ -63,3 +63,6 @@ Side effects inline:
 - **Candidate rejected with load-bearing reason?** Offer an ADR
 
 See [INTERFACE-DESIGN.md](./INTERFACE-DESIGN.md) for exploring alternative interfaces.
+
+### 4. Close the hygiene cycle
+When the grilling loop ends (whether work was done or the human decided to skip), delete `.plans/hygiene_report.md`. Its informational purpose has been served — the human reviewed it, decided what to act on, and either acted or deferred. Leaving it in `.plans/` would cause the next hygiene sweep to flag it as orphaned per the Section 6.5 Coordination Contract Audit.

--- a/.agents/skills/lfe-inspector/SKILL.md
+++ b/.agents/skills/lfe-inspector/SKILL.md
@@ -32,7 +32,20 @@ Verify that the implementation matches the domain truth and numerical baselines.
 3. **Verify Baselines**: If your project keeps validation snapshots in `.docs/quality/validation-baselines.md`, confirm the implementation matches them. (The file is a template; populated only when your project has reproducible golden outputs.)
 4. **Verify TDD Report (or Protocol Debt entry)**: Read `.plans/tdd_report.md` and confirm test coverage matches the plan's requirements. If that file is absent because the work arrived via `LFE-FORCE`, follow Hard Rule #4's fallback: read the latest unresolved entry in `.docs/quality/PROTOCOL_DEBT.md` and verify the hotfix directly. Mark the verification's `source:` field accordingly.
 5. **Instrument** (mission path only): If behavior is suspicious AND `source: .plans/tdd_report.md`, use `/lfe-diagnose` to build a repro loop and identify root cause. **Do NOT trigger `/lfe-diagnose` on the LFE-FORCE recovery path** — Diagnose returns to Builder, which would read a non-existent `active_plan.md`. See Step 7b instead.
-6. **Reflect (4-Eyes Principle)**: Before writing the final report, write a `.plans/critique.md` acting as a "Devil's Advocate" against the implementation (or, on the LFE-FORCE path, against the hotfix). Look for edge cases, performance regressions, or undocumented technical debt. Mark the `critique ✅` checkbox in `pipeline_status.md`.
+6. **Reflect (4-Eyes Principle)**: Before writing the final report, write a `.plans/critique.md` acting as a "Devil's Advocate" against the implementation (or, on the LFE-FORCE path, against the hotfix). Look for edge cases, performance regressions, or undocumented technical debt. Frontmatter follows the contract in [`COORDINATION_FILES.md`](../../../.docs/protocol/COORDINATION_FILES.md):
+
+```yaml
+---
+phase: inspector
+step: critique
+status: complete
+timestamp: <ISO-8601>
+source: .plans/tdd_report.md   # or .docs/quality/PROTOCOL_DEBT.md on LFE-FORCE recovery
+slice: <copied from active_plan.md; omit on LFE-FORCE recovery path>
+---
+```
+
+Body: free-form Devil's Advocate analysis. Mark the `critique ✅` checkbox in `pipeline_status.md`.
 7. **Write Report**: Save verification results to `.plans/inspection_report.md`:
 
 ```yaml

--- a/.agents/skills/lfe-inspector/SKILL.md
+++ b/.agents/skills/lfe-inspector/SKILL.md
@@ -23,7 +23,7 @@ Verify that the implementation matches the domain truth and numerical baselines.
 3. **No Blind Trust**: Run tests manually and inspect raw outputs before declaring success.
 4. **File-Based Input** (with explicit fallback):
    - **Primary**: read `.plans/tdd_report.md`. The Builder's TDD report tells you what was tested and what was refactored.
-   - **Fallback (LFE-FORCE recovery)**: if `.plans/tdd_report.md` does NOT exist AND `.docs/quality/PROTOCOL_DEBT.md` has at least one unresolved entry, read the latest unresolved Protocol Debt entry instead and verify the hotfix described there directly against `src/`. Set `source: PROTOCOL_DEBT.md` in the inspection report frontmatter. This path is the ONLY way to clear Protocol Debt — the framework MUST never deadlock here.
+   - **Fallback (LFE-FORCE recovery)**: if `.plans/tdd_report.md` does NOT exist AND `.docs/quality/PROTOCOL_DEBT.md` has at least one unresolved entry, read the latest unresolved Protocol Debt entry instead and verify the hotfix described there directly against `src/`. Set `source: .docs/quality/PROTOCOL_DEBT.md` in the inspection report frontmatter — exact full path, because Archivist Step 3.6's matcher keys off this string verbatim. This path is the ONLY way to clear Protocol Debt — the framework MUST never deadlock here.
    - **Hard fail**: if neither input exists, halt and ask the human whether to escalate to `/lfe-extract-domain` (true black box) rather than fabricate a verification.
 
 ## Workflow

--- a/.agents/skills/lfe-tdd/SKILL.md
+++ b/.agents/skills/lfe-tdd/SKILL.md
@@ -96,7 +96,7 @@ phase: builder
 step: tdd
 status: complete
 timestamp: <ISO-8601>
-source: active_plan.md
+source: .plans/active_plan.md
 slice: <copied from active_plan.md>
 tests_passed: <N>
 tests_failed: 0

--- a/.docs/protocol/COORDINATION_FILES.md
+++ b/.docs/protocol/COORDINATION_FILES.md
@@ -43,7 +43,7 @@ The Archivist enforces two cleanup tiers, defined in `lfe-archivist/SKILL.md`:
 - **Partial Cleanup** (between slices): delete execution files — `active_plan.md`, `builder_done.md`, `tdd_report.md`, `critique.md`, `inspection_report.md`, `diagnosis_report.md`. **Keep** planning files — `01_grill_summary.md`, `02_prd.md`, `03_slices.md`.
 - **Full Cleanup** (mission complete): delete every file in `.plans/`.
 
-`hygiene_report.md` belongs to the Hygiene sub-pipeline and is consumed by `/lfe-improve-architecture`, then cleared at end of the hygiene cycle — not by per-mission Archivist runs.
+`hygiene_report.md` belongs to the Hygiene sub-pipeline. Its primary reader is the **human** (audit findings to review and triage). `/lfe-improve-architecture` may reference it for priority context but does not formally consume it — that skill walks the codebase fresh. The report is deleted by `/lfe-improve-architecture`'s final step at the end of the hygiene cycle, not by per-mission Archivist runs.
 
 ## Why this exists
 


### PR DESCRIPTION
Stacked on top of [#30](https://github.com/StChiotis/Library-First-Engineering/pull/30). Final small sweep on Cluster A before the chain merges. Each change closes a real failure mode (or fixes an inconsistency I shipped); none add ceremony; none remove a human gate.

## What's in

### G4.1 — `/lfe-improve-architecture` cleans `hygiene_report.md`
I asserted in `COORDINATION_FILES.md` that improve-architecture consumed and cleared `hygiene_report.md`. Reading the actual skill, it does neither. The doc was wrong, AND my new Section 6.5 frontmatter check from PR #30 would now flag the orphan.
- improve-architecture gets a Step 4 (Close the hygiene cycle) that deletes the report at end of the grilling loop.
- `COORDINATION_FILES.md` now describes the actual flow: human is the primary reader; improve-architecture references for context if useful; deletes at hygiene-cycle end.

### G4.3 (soft) — soften "MUST" in `lfe-hygiene` output
The hygiene report said "Critical findings MUST be resolved by the Architect before any further refactoring" — implying an enforcement that doesn't exist (`lfe-boot` doesn't block on hygiene). Adding boot-level enforcement would remove human judgment about when to act — anti-pattern. Softened to: "should be reviewed and triaged by the human; the framework surfaces but does not block — when to act is a human judgment call."

### A3.1 — Archivist Step 7 surfaces the multi-slice trade-off
Hygiene runs every 5 sessions. If the timer hits mid-multi-slice, improve-architecture may refactor `src/` and invalidate planning files for remaining slices. The framework already lets the human defer (recommend, not enforce), but the prompt didn't explain the trade-off. Step 7 now branches:
- **If `03_slices.md` has unfinished slices**: prompt warns and offers Run / defer to mission end / skip
- **Otherwise**: prompt as before

Human gate preserved; context improved.

### `critique.md` frontmatter
Every other coordination file had a YAML schema in its producer skill; `critique.md` was "just write a markdown file." My new Section 6.5 hygiene check from PR #30 would have flagged it. Added a small frontmatter block (`phase / step / status / timestamp / source / slice`) to `/lfe-inspector` Step 6.

## What was cut after audit

| Item | Reason |
|---|---|
| **G4.3 (hard)** — boot-level enforcement of unresolved critical hygiene findings | Removes human judgment about when to act on hygiene findings. The current state — surface, don't enforce — is correct. Only the wording was misleading. |
| **G5.3** — Archivist workflow Step 2 feels feature-centric on LFE-FORCE recovery | Step 2's sub-actions are already conditional ("if new domain terms... if new math rules..."). For a hotfix with no domain content, the agent legitimately skips them. Cosmetic concern, not reliability. |
| **G5.4** — Inspector workflow body still TDD-centric on LFE-FORCE recovery | "Verify Logic against domain formulas" is still the right action whether the implementation came from Builder or from a hotfix. Cosmetic concern, not reliability. |
| **C1.4** — Persist failed inspection_report so triage choice survives | Already adjudicated under Cluster A.1's S7 cut: re-asking IS the human gate. Context may have changed between sessions. |

## Self-review

- improve-architecture's new Step 4 matches the COORDINATION_FILES.md assertion (no more drift).
- The softened hygiene output language matches what the framework actually does.
- Archivist Step 7's branching prompt asks the human; doesn't decide for them.
- critique.md schema mirrors the contract; Section 6.5 will pass.
- No new files. No new ceremony. No new gates.

## Known size overruns (issue #5 territory)

| File | Before | After |
|---|---|---|
| `lfe-inspector/SKILL.md` | 5946 | 6363 (newly over) |
| `lfe-archivist/SKILL.md` | 6753 | 7621 |
| `lfe-hygiene/SKILL.md` | 6301 | 6476 |

All Cluster D work; out of scope here.

## Test plan

- [ ] Walk a hygiene-then-improve-architecture cycle: confirm Step 4 deletes `hygiene_report.md`
- [ ] Read updated hygiene output language; confirm "should/triage" replaces "MUST/resolve"
- [ ] Mid-multi-slice scenario: confirm Archivist Step 7 prompt includes the trade-off warning
- [ ] Read `lfe-inspector` Step 6 critique schema; confirm it satisfies COORDINATION_FILES.md's required fields
- [ ] Mentally run Section 6.5 frontmatter check against a fresh `.plans/` state with `critique.md` present — passes