### PR TITLE
chore(framework): add .gitattributes + fix malformed doc link

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Library-First Engineering — line-ending & binary policy
+#
+# Normalize all text files to LF in the repository and working tree. This keeps
+# adopters who pull upstream framework updates from seeing spurious CRLF/LF
+# whole-file diffs across platforms (Windows/macOS/Linux). The policy is
+# generic and project-agnostic — safe for any clone of the blank scaffold.
+
+* text=auto eol=lf
+
+# Binary assets — never normalize line endings or diff as text.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.woff2 binary
+*.ttf   binary

--- a/LLM_AGENT_GUIDE.md
+++ b/LLM_AGENT_GUIDE.md
@@ -6,7 +6,7 @@
 This project follows the **Library-First Engineering (LFE)** protocol. Every AI agent working on this repo must treat documentation as the **Single Source of Truth (SSOT)** and follow a disciplined persona-based workflow with file-based coordination.
 
 ## 2. The Agnostic Protocol
-Your behavior is strictly governed by the Agnostic Core documents. Before taking any action, you **MUST** ingest the current state of the project's protocol following the strict static ingestion order defined in Step 3 of [/lfe-boot](file:///.agents/skills/lfe-boot/SKILL.md) to maximize KV cache hits.
+Your behavior is strictly governed by the Agnostic Core documents. Before taking any action, you **MUST** ingest the current state of the project's protocol following the strict static ingestion order defined in Step 3 of [/lfe-boot](.agents/skills/lfe-boot/SKILL.md) to maximize KV cache hits.
 
 ## 3. The Source-of-Truth Hierarchy & Boundaries
 


### PR DESCRIPTION
@
## What

Two small, scaffold-safe framework-maintenance fixes surfaced by an open-issue triage pass:

- **`.gitattributes`** (new) — minimal, project-agnostic line-ending + binary policy. `* text=auto eol=lf` normalizes all text to LF; image/font assets marked `binary`. Spares adopters who pull upstream updates from spurious CRLF/LF whole-file diffs. **Closes #43.**
- **`LLM_AGENT_GUIDE.md` §2** — fix a malformed `file:///.agents/...` link to a bare relative path (`.agents/...`); it was the sole `file://` occurrence repo-wide. **Refs #42** (the one live defect in that issue).

## Verification

- `git add --renormalize .` produced **zero churn** across all 122 tracked text files — only the new `.gitattributes` and the one-line doc edit appear. No mass line-ending rewrite.
- The doc change is a single-line link-format fix; surrounding prose is byte-identical.

## Scaffold integrity

The blank canvas is unchanged: `pipeline_status.md` still `[BLANK CANVAS]` (Session Count 0, Active Mission none), `src/` and `.plans/` hold only their `.gitkeep`, `CONTEXT.md` still the template. Both changes are pure framework infrastructure — no domain or product content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@